### PR TITLE
Add push job into networkservicemeshci docker repository

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -1,0 +1,27 @@
+---
+name: push
+on:
+  push:
+    branches:
+      - master
+jobs:
+  pushImage:
+    name: push image
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USER: ${{ secrets.DOCKER_LOGIN }}
+      TAG: master
+      ORG: networkservicemeshci
+      CGO_ENABLED: 0
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.4
+      - name: Build container
+        run: docker build .
+      - name: Push coredns image
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          docker push "${ORG}/memory-registry:${TAG}"
+          docker image rm "${ORG}/memory-registry:${TAG}"

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: 1.13.4
       - name: Build container
-        run: docker build .
+        run: docker build . -t "${ORG}/memory-registry:${TAG}"
       - name: Push coredns image
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
           docker push "${ORG}/memory-registry:${TAG}"


### PR DESCRIPTION
## Motivation

Github docker repositories are not working at this moment.

```
time="2020-08-06T12:10:38Z" level=info msg="Events:"
time="2020-08-06T12:10:38Z" level=info msg="  Type     Reason     Age                 From                         Message"
time="2020-08-06T12:10:38Z" level=info msg="  ----     ------     ----                ----                         -------"
time="2020-08-06T12:10:38Z" level=info msg="  Normal   Scheduled  2m                  default-scheduler            Successfully assigned default/memory-registry-7c8fc88988-8vnhf to kind-control-plane"
time="2020-08-06T12:10:38Z" level=info msg="  Normal   Pulling    27s (x4 over 119s)  kubelet, kind-control-plane  Pulling image \"docker.pkg.github.com/networkservicemesh/cmd-registry-memory/cmd-registry-memory:latest\""
time="2020-08-06T12:10:38Z" level=info msg="  Warning  Failed     27s (x4 over 119s)  kubelet, kind-control-plane  Failed to pull image \"docker.pkg.github.com/networkservicemesh/cmd-registry-memory/cmd-registry-memory:latest\": rpc error: code = Unknown desc = failed to pull and unpack image \"docker.pkg.github.com/networkservicemesh/cmd-registry-memory/cmd-registry-memory:latest\": failed to resolve reference \"docker.pkg.github.com/networkservicemesh/cmd-registry-memory/cmd-registry-memory:latest\": unexpected status code [manifests latest]: 401 Unauthorized"
time="2020-08-06T12:10:38Z" level=info msg="  Warning  Failed     27s (x4 over 119s)  kubelet, kind-control-plane  Error: ErrImagePull"
time="2020-08-06T12:10:38Z" level=info msg="  Normal   BackOff    15s (x6 over 118s)  kubelet, kind-control-plane  Back-off pulling image \"docker.pkg.github.com/networkservicemesh/cmd-registry-memory/cmd-registry-memory:latest\""
time="2020-08-06T12:10:38Z" level=info msg="  Warning  Failed     1s (x7 over 118s)   kubelet, kind-control-plane  Error: ImagePullBackOff"
```

This PR adds possible to push docker images into nsmci docker repository.