### PR TITLE
Add grpc.WithBlock() to fix problems with unix based connection in k8s

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 			return chain.NewNetworkServiceEndpointRegistryClient(
 				api_registry.NewNetworkServiceEndpointRegistryClient(cc),
 			)
-		}),
+		}, connect.WithClientDialOptions(grpc.WithBlock())),
 	)
 
 	nsChain := chain.NewNetworkServiceRegistryServer(
@@ -116,7 +116,7 @@ func main() {
 			return chain.NewNetworkServiceRegistryClient(
 				api_registry.NewNetworkServiceRegistryClient(cc),
 			)
-		}),
+		}, connect.WithClientDialOptions(grpc.WithBlock())),
 	)
 
 	// Create GRPC Server and register services


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

Based on discussions:
1. https://github.com/networkservicemesh/sdk/pull/445
2. https://github.com/networkservicemesh/sdk/pull/446#pullrequestreview-472247371