### PR TITLE
fix: docker tests for cmd-registry-memory  is outdated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,6 +214,8 @@ jobs:
   update-deployments-k8s:
     name: Update deployments-k8s
     runs-on: ubuntu-latest
+    needs:
+      - pushImage
     if: github.repository != 'networkservicemesh/cmd-template' && github.actor == 'nsmbot' && github.base_ref == 'master' && github.event_name == 'pull_request'
     steps:
       - name: Checkout ${{ github.repository }}

--- a/main_test.go
+++ b/main_test.go
@@ -203,7 +203,9 @@ func (t *RegistryTestSuite) TestNetworkServiceEndpointRegistration() {
 
 	t.Nil(err)
 	t.NotEmpty(result.Name)
-	stream, err := client.Find(context.Background(), &registry.NetworkServiceEndpointQuery{NetworkServiceEndpoint: result})
+	stream, err := client.Find(context.Background(), &registry.NetworkServiceEndpointQuery{NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+		Name: result.Name,
+	}})
 	t.Nil(err)
 	list := registry.ReadNetworkServiceEndpointList(stream)
 	t.Len(list, 1)
@@ -245,7 +247,8 @@ func (t *RegistryTestSuite) TestNetworkServiceEndpointRegistrationExpiration() {
 		t.Nil(err)
 		list = registry.ReadNetworkServiceEndpointList(stream)
 		return len(list) == 0
-	}, time.Second*5, time.Millisecond*100)
+	}, time.Until(result.GetExpirationTime().AsTime())+time.Second*5, time.Millisecond*100)
+
 }
 
 func (t *RegistryTestSuite) TestNetworkServiceEndpointClientRefreshingTime() {

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -248,7 +248,6 @@ func (t *RegistryTestSuite) TestNetworkServiceEndpointRegistrationExpiration() {
 		list = registry.ReadNetworkServiceEndpointList(stream)
 		return len(list) == 0
 	}, time.Until(result.GetExpirationTime().AsTime())+time.Second*5, time.Millisecond*100)
-
 }
 
 func (t *RegistryTestSuite) TestNetworkServiceEndpointClientRefreshingTime() {


### PR DESCRIPTION
Closes: https://github.com/networkservicemesh/cmd-registry-memory/pull/171